### PR TITLE
docs: Fix a few typos

### DIFF
--- a/zxcvbn/scoring.py
+++ b/zxcvbn/scoring.py
@@ -131,7 +131,7 @@ def round_to_x_digits(number, digits):
 #
 # assumes:
 # * passwords are stored as salted hashes, different random salt per user.
-#   (making rainbow attacks infeasable.)
+#   (making rainbow attacks infeasible.)
 # * hashes and salts were stolen. attacker is guessing passwords at max rate.
 # * attacker has several CPUs at their disposal.
 # ------------------------------------------------------------------------------

--- a/zxcvbn/scripts/build_frequency_lists.py
+++ b/zxcvbn/scripts/build_frequency_lists.py
@@ -14,7 +14,7 @@ SLEEP_TIME = 20 # seconds
 
 def get_ranked_english():
     '''
-    wikitionary has a list of ~40k English words, ranked by frequency of occurance in TV and movie transcripts.
+    wikitionary has a list of ~40k English words, ranked by frequency of occurrence in TV and movie transcripts.
     more details at:
     http://en.wiktionary.org/wiki/Wiktionary:Frequency_lists/TV/2006/explanation
 


### PR DESCRIPTION
There are small typos in:
- zxcvbn/scoring.py
- zxcvbn/scripts/build_frequency_lists.py

Fixes:
- Should read `occurrence` rather than `occurance`.
- Should read `infeasible` rather than `infeasable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md